### PR TITLE
Initialize clock early enough

### DIFF
--- a/drivers/clk/baikal/clk-baikal.c
+++ b/drivers/clk/baikal/clk-baikal.c
@@ -245,10 +245,9 @@ static int baikal_clk_probe(struct platform_device *pdev)
 	const char *clk_ch_name;
 	const char *parent_name;
 
-	cmu = kmalloc(sizeof(struct baikal_clk_cmu *), GFP_KERNEL);
+	cmu = kzalloc(sizeof(struct baikal_clk_cmu), GFP_KERNEL);
 	if (!cmu) {
 		pr_err("%s: could not allocate CMU clk\n", __func__);
-		kfree(cmu);
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
Currently clk-baikal gets initialized way too late: after starting secondary CPUs, probing PCI-e, etc:

```  
[    1.063892] Asymmetric key parser 'x509' registered
[    1.069345] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
[    1.077756] io scheduler mq-deadline registered
[    1.082848] io scheduler bfq registered
[    1.087526] crc32: CRC_LE_BITS = 64, CRC_BE BITS = 64
[    1.093158] crc32: self tests passed, processed 225944 bytes in 184000 nsec
[    1.100987] crc32c: CRC_LE_BITS = 64
[    1.104969] crc32c: self tests passed, processed 225944 bytes in 29980 nsec
[    1.125936] crc32_combine: 8373 self tests passed
[    1.144367] crc32c_combine: 8373 self tests passed
[    1.152032] gpio-481 (pcie-x8-clock): hogged as output/high
[    1.159813] efifb: probing for efifb
[    1.164093] efifb: No BGRT, not showing boot graphics
[    1.169726] efifb: framebuffer at 0xfb1a6000, using 8100k, total 8100k
[    1.177005] efifb: mode is 1920x1080x32, linelength=7680, pages=1
[    1.183800] efifb: scrolling: redraw
[    1.187781] efifb: Truecolor: size=8:8:8:8, shift=24:16:8:0
[    1.194106] fbcon: Deferring console take-over
[    1.199068] fb0: EFI VGA frame buffer device
[    1.204451] baikal_clk_probe index 0 name <gpio> i 0
[    1.210133] baikal_clk_probe index 1 name <uart1> i 1
[    1.215903] baikal_clk_probe index 2 name <uart2> i 2
[    1.221672] baikal_clk_probe index 3 name <apb> i 3
[    1.227247] baikal_clk_probe index 4 name <spi> i 4
[    1.232821] baikal_clk_probe index 5 name <espi> i 5
[    1.238493] baikal_clk_probe index 6 name <i2c1> i 6
```

This is wrong, clock driver should be initialized *much* earlier. Use CLK_OF_DECLARE_DRIVER to ensure clock gets probed at a proper stage of kernel initialization. With this patch:

```
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 768 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] GICv3: Distributor has no Range Selector support
[    0.000000] GICv3: 16 PPIs implemented
[    0.000000] GICv3: no VLPI support, no direct LPI support
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000002d100000
[    0.000000] ITS [mem 0x2d020000-0x2d03ffff]
[    0.000000] ITS@0x000000002d020000: allocated 262144 Devices @bec200000 (flat, esz 8, psz 64K, shr 0)
[    0.000000] ITS: using cache flushing for cmd queue
[    0.000000] GICv3: using LPI property table @0x0000000bec130000
[    0.000000] GIC: using cache flushing for LPI property table
[    0.000000] GICv3: CPU0: using allocated LPI pending table @0x0000000bec140000
[    0.000000] random: get_random_bytes called from start_kernel+0x338/0x4b8 with crng_init=0
[    0.000000] baikal_clk_init: successfully probed /cmu_cluster0
[    0.000000] baikal_clk_init: successfully probed /cmu_cluster1
[    0.000000] baikal_clk_init: successfully probed /cmu_cluster2
[    0.000000] baikal_clk_init: successfully probed /cmu_cluster3
[    0.000000] baikal_clk_init: successfully probed clock /cmu0_avlsp
[    0.000000] baikal_clk_init: successfully probed clock /cmu1_avlsp
[    0.000000] baikal_clk_init: successfully probed clock /cmu_mali
[    0.000000] baikal_clk_init: successfully probed clock /cmu0_xgbe
[    0.000000] baikal_clk_init: successfully probed clock /cmu1_xgbe
```

Note: as a side effect `dw-pcie` driver is able to initialize and successfully drive PCI-E devices (4x NVME drive).